### PR TITLE
Remove artwork overlay labels

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@tailwindcss/vite": "^4",
         "@tauri-apps/cli": "^2.0.0",
-        "@types/bun": "latest",
+        "@types/bun": "^1.3.12",
         "@types/node": "^24.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1347,11 +1347,6 @@ function PreviewColumn({ game, isAttract }: { game: GameRecord; isAttract: boole
         />
 
         <div className="absolute inset-[3%] flex flex-col justify-between pointer-events-none">
-          <div className="flex items-start justify-between font-display tracking-[0.25em] text-cab-mute" style={{ fontSize: "1.9cqh", textShadow: "0 0.25cqh 0.8cqh #000" }}>
-            <span>PREVIEW</span>
-            <span>{game.machineName.toUpperCase()}</span>
-          </div>
-
           {game.attractCaption && previewMedia.kind === "none" && (
             <p
               className="font-sans leading-[1.2] text-cab-ink max-w-[80%]"


### PR DESCRIPTION
## Summary
- Remove the `PREVIEW` and machine name overlay from the artwork display
- Keep the preview media and attract-caption fallback unchanged
- Pin `@types/bun` in the lockfile

## Testing
- Not run (not requested)