### PR TITLE
Fix Linux video playback and MAME launch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@tailwindcss/vite": "^4",
         "@tauri-apps/cli": "^2.0.0",
-        "@types/bun": "latest",
+        "@types/bun": "^1.3.12",
         "@types/node": "^24.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",

--- a/src-tauri/src/launcher.rs
+++ b/src-tauri/src/launcher.rs
@@ -38,6 +38,17 @@ pub fn build_mame_launch(
         args.push(mame_ini_search_path(mame_ini_path).into_os_string());
     }
 
+    let rom_roots = cabinet_config
+        .paths
+        .rom_roots
+        .iter()
+        .filter_map(|root| non_empty_string(root))
+        .collect::<Vec<_>>();
+    if !rom_roots.is_empty() {
+        args.push(OsString::from("-rompath"));
+        args.push(OsString::from(join_mame_search_path(&rom_roots)));
+    }
+
     args.push(OsString::from(machine_name));
 
     Ok(MameLaunch {
@@ -80,6 +91,10 @@ fn mame_ini_search_path(mame_ini_path: &str) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
+fn join_mame_search_path(paths: &[&str]) -> String {
+    paths.join(";")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,6 +131,27 @@ mod tests {
         assert_eq!(
             args_as_strings(&launch),
             vec!["-inipath", "/etc/mame", "galaga"],
+        );
+    }
+
+    #[test]
+    fn build_mame_launch_passes_configured_rom_roots() {
+        let mut cabinet_config = cabinet_config();
+        cabinet_config.paths.rom_roots = vec![
+            "/srv/karlo/library/roms/mame".to_owned(),
+            " ".to_owned(),
+            "/mnt/arcade/roms".to_owned(),
+        ];
+
+        let launch = build_mame_launch(&cabinet_config, "sf2").unwrap();
+
+        assert_eq!(
+            args_as_strings(&launch),
+            vec![
+                "-rompath",
+                "/srv/karlo/library/roms/mame;/mnt/arcade/roms",
+                "sf2",
+            ],
         );
     }
 

--- a/src-tauri/src/media_protocol.rs
+++ b/src-tauri/src/media_protocol.rs
@@ -1,4 +1,5 @@
-use std::fs;
+use std::fs::{self, File};
+use std::io::{Read, Seek, SeekFrom};
 use std::path::PathBuf;
 
 use tauri::http::{header, Request, Response, StatusCode};
@@ -15,20 +16,13 @@ pub fn handle_media_request(request: Request<Vec<u8>>) -> Response<Vec<u8>> {
         );
     }
 
-    match fs::read(&path) {
-        Ok(data) => Response::builder()
-            .header(header::CONTENT_TYPE, content_type_for(&path))
-            .header(header::CONTENT_LENGTH, data.len().to_string())
-            .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .body(data)
-            .unwrap_or_else(|_| {
-                text_response(StatusCode::INTERNAL_SERVER_ERROR, "media response failed")
-            }),
-        Err(error) => text_response(
-            StatusCode::NOT_FOUND,
-            &format!("media file could not be read: {error}"),
-        ),
-    }
+    let range = request
+        .headers()
+        .get(header::RANGE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| parse_byte_range(value));
+
+    file_response(&path, range)
 }
 
 fn request_path(uri_path: &str) -> Option<PathBuf> {
@@ -77,6 +71,145 @@ fn content_type_for(path: &PathBuf) -> &'static str {
     }
 }
 
+fn file_response(path: &PathBuf, requested_range: Option<RequestedRange>) -> Response<Vec<u8>> {
+    let Ok(mut file) = File::open(path) else {
+        return text_response(StatusCode::NOT_FOUND, "media file could not be read");
+    };
+
+    let Ok(metadata) = file.metadata() else {
+        return text_response(
+            StatusCode::NOT_FOUND,
+            "media file metadata could not be read",
+        );
+    };
+    let file_len = metadata.len();
+
+    if let Some(requested_range) = requested_range {
+        let Some(range) = requested_range.resolve(file_len) else {
+            return Response::builder()
+                .status(StatusCode::RANGE_NOT_SATISFIABLE)
+                .header(header::CONTENT_RANGE, format!("bytes */{file_len}"))
+                .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+                .body(Vec::new())
+                .unwrap_or_else(|_| range_error_response());
+        };
+
+        return match read_file_range(&mut file, range.start, range.len()) {
+            Ok(data) => Response::builder()
+                .status(StatusCode::PARTIAL_CONTENT)
+                .header(header::CONTENT_TYPE, content_type_for(path))
+                .header(header::CONTENT_LENGTH, data.len().to_string())
+                .header(header::ACCEPT_RANGES, "bytes")
+                .header(
+                    header::CONTENT_RANGE,
+                    format!("bytes {}-{}/{}", range.start, range.end, file_len),
+                )
+                .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+                .body(data)
+                .unwrap_or_else(|_| range_error_response()),
+            Err(error) => text_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("media range could not be read: {error}"),
+            ),
+        };
+    }
+
+    match fs::read(path) {
+        Ok(data) => Response::builder()
+            .header(header::CONTENT_TYPE, content_type_for(path))
+            .header(header::CONTENT_LENGTH, data.len().to_string())
+            .header(header::ACCEPT_RANGES, "bytes")
+            .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+            .body(data)
+            .unwrap_or_else(|_| {
+                text_response(StatusCode::INTERNAL_SERVER_ERROR, "media response failed")
+            }),
+        Err(error) => text_response(
+            StatusCode::NOT_FOUND,
+            &format!("media file could not be read: {error}"),
+        ),
+    }
+}
+
+fn read_file_range(file: &mut File, start: u64, len: u64) -> Result<Vec<u8>, String> {
+    file.seek(SeekFrom::Start(start))
+        .map_err(|error| error.to_string())?;
+    let mut reader = file.take(len);
+    let mut data = Vec::with_capacity(len.min(usize::MAX as u64) as usize);
+    reader
+        .read_to_end(&mut data)
+        .map_err(|error| error.to_string())?;
+    Ok(data)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RequestedRange {
+    start: Option<u64>,
+    end: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ResolvedRange {
+    start: u64,
+    end: u64,
+}
+
+impl ResolvedRange {
+    fn len(self) -> u64 {
+        self.end - self.start + 1
+    }
+}
+
+impl RequestedRange {
+    fn resolve(self, file_len: u64) -> Option<ResolvedRange> {
+        if file_len == 0 {
+            return None;
+        }
+
+        match (self.start, self.end) {
+            (Some(start), Some(end)) if start <= end && start < file_len => Some(ResolvedRange {
+                start,
+                end: end.min(file_len - 1),
+            }),
+            (Some(start), None) if start < file_len => Some(ResolvedRange {
+                start,
+                end: file_len - 1,
+            }),
+            (None, Some(suffix_len)) if suffix_len > 0 => {
+                let len = suffix_len.min(file_len);
+                Some(ResolvedRange {
+                    start: file_len - len,
+                    end: file_len - 1,
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
+fn parse_byte_range(value: &str) -> Option<RequestedRange> {
+    let range = value.trim().strip_prefix("bytes=")?;
+    let range = range.split(',').next()?.trim();
+    let (start, end) = range.split_once('-')?;
+
+    let start = if start.trim().is_empty() {
+        None
+    } else {
+        Some(start.trim().parse::<u64>().ok()?)
+    };
+    let end = if end.trim().is_empty() {
+        None
+    } else {
+        Some(end.trim().parse::<u64>().ok()?)
+    };
+
+    if start.is_none() && end.is_none() {
+        return None;
+    }
+
+    Some(RequestedRange { start, end })
+}
+
 fn text_response(status: StatusCode, message: &str) -> Response<Vec<u8>> {
     Response::builder()
         .status(status)
@@ -84,6 +217,13 @@ fn text_response(status: StatusCode, message: &str) -> Response<Vec<u8>> {
         .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
         .body(message.as_bytes().to_vec())
         .unwrap()
+}
+
+fn range_error_response() -> Response<Vec<u8>> {
+    text_response(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "media range response failed",
+    )
 }
 
 fn percent_decode(value: &str) -> String {
@@ -150,6 +290,68 @@ mod tests {
         assert_eq!(
             content_type_for(&PathBuf::from("preview.bin")),
             "application/octet-stream"
+        );
+    }
+
+    #[test]
+    fn parse_byte_range_accepts_common_video_ranges() {
+        assert_eq!(
+            parse_byte_range("bytes=0-1023"),
+            Some(RequestedRange {
+                start: Some(0),
+                end: Some(1023),
+            })
+        );
+        assert_eq!(
+            parse_byte_range("bytes=1024-"),
+            Some(RequestedRange {
+                start: Some(1024),
+                end: None,
+            })
+        );
+        assert_eq!(
+            parse_byte_range("bytes=-512"),
+            Some(RequestedRange {
+                start: None,
+                end: Some(512),
+            })
+        );
+        assert_eq!(parse_byte_range("items=0-1023"), None);
+    }
+
+    #[test]
+    fn requested_range_resolves_against_file_length() {
+        assert_eq!(
+            RequestedRange {
+                start: Some(5),
+                end: Some(20),
+            }
+            .resolve(10),
+            Some(ResolvedRange { start: 5, end: 9 })
+        );
+        assert_eq!(
+            RequestedRange {
+                start: Some(5),
+                end: None,
+            }
+            .resolve(10),
+            Some(ResolvedRange { start: 5, end: 9 })
+        );
+        assert_eq!(
+            RequestedRange {
+                start: None,
+                end: Some(4),
+            }
+            .resolve(10),
+            Some(ResolvedRange { start: 6, end: 9 })
+        );
+        assert_eq!(
+            RequestedRange {
+                start: Some(10),
+                end: None,
+            }
+            .resolve(10),
+            None
         );
     }
 }


### PR DESCRIPTION
## Summary
- Add byte-range support to the custom media protocol so Linux WebKit/GStreamer can stream preview videos reliably
- Pass configured ROM roots through to MAME with `-rompath` so cabinet launches can find game sets
- Add unit coverage for range parsing, range resolution, and ROM path wiring

## Testing
- `bun test ./src/**/*.test.ts`
- `bun run build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo test --manifest-path src-tauri/Cargo.toml`