### PR TITLE
Fix cabinet video previews and screensaver playback

### DIFF
--- a/.github/workflows/linux-artifact.yml
+++ b/.github/workflows/linux-artifact.yml
@@ -55,10 +55,14 @@ jobs:
             libfuse2 \
             patchelf \
             wget \
+            gstreamer1.0-gl \
             gstreamer1.0-libav \
             gstreamer1.0-plugins-bad \
             gstreamer1.0-plugins-base \
-            gstreamer1.0-plugins-good
+            gstreamer1.0-plugins-base-apps \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-ugly \
+            gstreamer1.0-tools
 
       - run: bun install --frozen-lockfile
       - run: bun test

--- a/ops/cabinet.env.example
+++ b/ops/cabinet.env.example
@@ -35,6 +35,10 @@ KARLO_OPTIMIZE_BOOT=1
 # Tauri/WebKit is more reliable there on the tested Ubuntu cabinet image.
 KARLO_SESSION_BACKEND=x11
 
+# Leave WebKit compositing enabled for video playback. Set to 1 only if the
+# cabinet shows a blank WebKit window with the normal compositor path.
+KARLO_WEBKIT_DISABLE_COMPOSITING=0
+
 # Weston shell used by the cabinet session. desktop is more compatible with
 # Tauri/WebKit than kiosk on some Ubuntu releases. Only used with
 # KARLO_SESSION_BACKEND=wayland.

--- a/ops/deploy-cabinet.sh
+++ b/ops/deploy-cabinet.sh
@@ -109,6 +109,7 @@ KARLO_RESTART="${KARLO_RESTART:-1}"
 KARLO_APP_BINARY="${KARLO_APP_BINARY:-/usr/bin/karlo}"
 KARLO_SESSION_BACKEND="${KARLO_SESSION_BACKEND:-x11}"
 KARLO_WESTON_SHELL="${KARLO_WESTON_SHELL:-desktop}"
+KARLO_WEBKIT_DISABLE_COMPOSITING="${KARLO_WEBKIT_DISABLE_COMPOSITING:-0}"
 
 [[ -n "${KARLO_GITHUB_REPO}" ]] || die "set KARLO_GITHUB_REPO or use a GitHub origin remote"
 [[ -n "${KARLO_GITHUB_REF}" ]] || die "set KARLO_GITHUB_REF or run from a branch"
@@ -162,7 +163,7 @@ ssh_remote_tty "sudo systemctl stop karlo-session.service >/dev/null 2>&1 || tru
 ssh_remote_tty "sudo apt-get install -y $(shell_quote "${REMOTE_DEB}")"
 
 if [[ "${KARLO_PROVISION}" == "1" ]]; then
-  ssh_remote_tty "sudo env KARLO_CABINET_USER=$(shell_quote "${KARLO_CABINET_USER}") KARLO_APP_BINARY=$(shell_quote "${KARLO_APP_BINARY}") KARLO_OPTIMIZE_BOOT=$(shell_quote "${KARLO_OPTIMIZE_BOOT}") KARLO_SESSION_BACKEND=$(shell_quote "${KARLO_SESSION_BACKEND}") KARLO_WESTON_SHELL=$(shell_quote "${KARLO_WESTON_SHELL}") bash $(shell_quote "${REMOTE_PROVISION}")"
+  ssh_remote_tty "sudo env KARLO_CABINET_USER=$(shell_quote "${KARLO_CABINET_USER}") KARLO_APP_BINARY=$(shell_quote "${KARLO_APP_BINARY}") KARLO_OPTIMIZE_BOOT=$(shell_quote "${KARLO_OPTIMIZE_BOOT}") KARLO_SESSION_BACKEND=$(shell_quote "${KARLO_SESSION_BACKEND}") KARLO_WESTON_SHELL=$(shell_quote "${KARLO_WESTON_SHELL}") KARLO_WEBKIT_DISABLE_COMPOSITING=$(shell_quote "${KARLO_WEBKIT_DISABLE_COMPOSITING}") bash $(shell_quote "${REMOTE_PROVISION}")"
   if [[ "${KARLO_PASSWORDLESS_SUDO}" == "1" ]]; then
     ssh_remote_tty "sudo install -d -m 0750 /etc/sudoers.d && echo $(shell_quote "${KARLO_CABINET_SSH_USER} ALL=(ALL) NOPASSWD:ALL") | sudo tee /etc/sudoers.d/90-karlo-deploy >/dev/null && sudo chmod 0440 /etc/sudoers.d/90-karlo-deploy && sudo visudo -cf /etc/sudoers.d/90-karlo-deploy"
   fi

--- a/ops/deploy-cabinet.sh
+++ b/ops/deploy-cabinet.sh
@@ -160,7 +160,7 @@ scp "${DEB_PATH}" "${REMOTE}:${REMOTE_DEB}"
 scp "${ROOT_DIR}/ops/provision-cabinet.sh" "${REMOTE}:${REMOTE_PROVISION}"
 
 ssh_remote_tty "sudo systemctl stop karlo-session.service >/dev/null 2>&1 || true"
-ssh_remote_tty "sudo apt-get install -y $(shell_quote "${REMOTE_DEB}")"
+ssh_remote_tty "sudo apt-get install -y --reinstall $(shell_quote "${REMOTE_DEB}")"
 
 if [[ "${KARLO_PROVISION}" == "1" ]]; then
   ssh_remote_tty "sudo env KARLO_CABINET_USER=$(shell_quote "${KARLO_CABINET_USER}") KARLO_APP_BINARY=$(shell_quote "${KARLO_APP_BINARY}") KARLO_OPTIMIZE_BOOT=$(shell_quote "${KARLO_OPTIMIZE_BOOT}") KARLO_SESSION_BACKEND=$(shell_quote "${KARLO_SESSION_BACKEND}") KARLO_WESTON_SHELL=$(shell_quote "${KARLO_WESTON_SHELL}") KARLO_WEBKIT_DISABLE_COMPOSITING=$(shell_quote "${KARLO_WEBKIT_DISABLE_COMPOSITING}") bash $(shell_quote "${REMOTE_PROVISION}")"

--- a/ops/provision-cabinet.sh
+++ b/ops/provision-cabinet.sh
@@ -6,6 +6,7 @@ APP_BINARY="${KARLO_APP_BINARY:-/usr/bin/karlo}"
 OPTIMIZE_BOOT="${KARLO_OPTIMIZE_BOOT:-1}"
 SESSION_BACKEND="${KARLO_SESSION_BACKEND:-x11}"
 WESTON_SHELL="${KARLO_WESTON_SHELL:-desktop}"
+WEBKIT_DISABLE_COMPOSITING="${KARLO_WEBKIT_DISABLE_COMPOSITING:-0}"
 SERVICE_PATH="/etc/systemd/system/karlo-session.service"
 SESSION_WRAPPER="/usr/local/bin/karlo-session"
 
@@ -41,6 +42,7 @@ run env DEBIAN_FRONTEND=noninteractive apt-get install -y \
   ca-certificates \
   dbus \
   dbus-user-session \
+  gstreamer1.0-gl \
   gstreamer1.0-libav \
   gstreamer1.0-plugins-bad \
   gstreamer1.0-plugins-base \
@@ -49,6 +51,7 @@ run env DEBIAN_FRONTEND=noninteractive apt-get install -y \
   gstreamer1.0-plugins-ugly \
   gstreamer1.0-tools \
   libayatana-appindicator3-1 \
+  libgl1-mesa-dri \
   librsvg2-2 \
   libwebkit2gtk-4.1-0 \
   libxdo3 \
@@ -95,8 +98,16 @@ exec >>"\${LOG_FILE}" 2>&1
 
 echo "--- Karlo session started at \$(date --iso-8601=seconds) ---"
 echo "SESSION_BACKEND=${SESSION_BACKEND}"
+WEBKIT_DISABLE_COMPOSITING="${WEBKIT_DISABLE_COMPOSITING}"
+echo "WEBKIT_DISABLE_COMPOSITING=\${WEBKIT_DISABLE_COMPOSITING}"
 echo "XDG_RUNTIME_DIR=\${XDG_RUNTIME_DIR:-}"
 echo "GDK_BACKEND=\${GDK_BACKEND:-}"
+
+if [[ "\${WEBKIT_DISABLE_COMPOSITING}" == "1" ]]; then
+  export WEBKIT_DISABLE_COMPOSITING_MODE=1
+else
+  unset WEBKIT_DISABLE_COMPOSITING_MODE
+fi
 
 if [[ "\${1:-}" != "--inside-dbus" ]]; then
   exec /usr/bin/dbus-run-session -- "\$0" --inside-dbus
@@ -183,7 +194,6 @@ Environment=GDK_BACKEND=${SESSION_BACKEND}
 Environment=GTK_USE_PORTAL=0
 Environment=NO_AT_BRIDGE=1
 Environment=RUST_BACKTRACE=1
-Environment=WEBKIT_DISABLE_COMPOSITING_MODE=1
 TTYPath=/dev/tty1
 TTYReset=yes
 TTYVHangup=yes

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use tauri::{AppHandle, Manager, State, WebviewWindow};
 
-use crate::{contract, db, launcher, store};
+use crate::{contract, db, launcher, media_server, store};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -21,8 +21,12 @@ pub struct SchemaOverview {
 #[tauri::command]
 pub fn get_frontend_bootstrap(
     state: State<'_, store::AppState>,
+    media_server: State<'_, media_server::MediaHttpServer>,
 ) -> Result<contract::FrontendBootstrap, String> {
-    Ok(contract::frontend_bootstrap(state.load_cabinet_config()?))
+    Ok(contract::frontend_bootstrap(
+        state.load_cabinet_config()?,
+        Some(media_server.base_url().to_owned()),
+    ))
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -135,6 +135,11 @@ pub fn get_schema_overview() -> SchemaOverview {
     }
 }
 
+#[tauri::command]
+pub fn report_frontend_diagnostic(event: String, details: String) {
+    eprintln!("[karlo] frontend diagnostic: {event} {details}");
+}
+
 fn restore_main_window(window: Option<WebviewWindow>) -> Result<(), String> {
     let Some(window) = window else {
         return Ok(());

--- a/src-tauri/src/contract.rs
+++ b/src-tauri/src/contract.rs
@@ -102,6 +102,7 @@ pub struct FrontendBootstrap {
     pub default_view: String,
     pub cabinet_config: CabinetConfig,
     pub curation: CurationContract,
+    pub media_http_base_url: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -175,11 +176,15 @@ pub fn default_cabinet_config() -> CabinetConfig {
     }
 }
 
-pub fn frontend_bootstrap(cabinet_config: CabinetConfig) -> FrontendBootstrap {
+pub fn frontend_bootstrap(
+    cabinet_config: CabinetConfig,
+    media_http_base_url: Option<String>,
+) -> FrontendBootstrap {
     FrontendBootstrap {
         default_view: DEFAULT_VIEW.to_owned(),
         cabinet_config,
         curation: curation_contract(),
+        media_http_base_url,
     }
 }
 
@@ -256,13 +261,20 @@ mod tests {
 
     #[test]
     fn frontend_bootstrap_exposes_cabinet_defaults() {
-        let bootstrap = frontend_bootstrap(default_cabinet_config());
+        let bootstrap = frontend_bootstrap(
+            default_cabinet_config(),
+            Some("http://127.0.0.1:43210".to_owned()),
+        );
 
         assert_eq!(bootstrap.default_view, "favorites");
         assert_eq!(bootstrap.cabinet_config.display_profile, "lcd-1440p-16:9");
         assert_eq!(bootstrap.cabinet_config.attract_timeout_seconds, 12);
         assert_eq!(bootstrap.curation.curated_library_table, "library_entries");
         assert_eq!(bootstrap.curation.browse_views.len(), 5);
+        assert_eq!(
+            bootstrap.media_http_base_url.as_deref(),
+            Some("http://127.0.0.1:43210")
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod db;
 mod importer;
 mod launcher;
 mod media_protocol;
+mod media_server;
 mod seed;
 mod store;
 
@@ -27,7 +28,10 @@ pub fn run() {
         .setup(|app| {
             let state =
                 store::AppState::initialize(app).map_err(|error| io::Error::other(error))?;
+            let media_server = media_server::MediaHttpServer::start(state.clone())
+                .map_err(|error| io::Error::other(error))?;
             app.manage(state);
+            app.manage(media_server);
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,8 +14,15 @@ use tauri::Manager;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
-        .register_uri_scheme_protocol("karlo-media", |_ctx, request| {
-            media_protocol::handle_media_request(request)
+        .register_uri_scheme_protocol("karlo-media", |ctx, request| {
+            let configured_roots = ctx
+                .app_handle()
+                .try_state::<store::AppState>()
+                .and_then(|state| state.load_cabinet_config().ok())
+                .map(|config| media_protocol::configured_media_roots(&config.paths))
+                .unwrap_or_default();
+
+            media_protocol::handle_media_request(request, &configured_roots)
         })
         .setup(|app| {
             let state =
@@ -34,7 +41,8 @@ pub fn run() {
             commands::save_cabinet_config,
             commands::scan_rom_roots,
             commands::toggle_game_favorite,
-            commands::get_schema_overview
+            commands::get_schema_overview,
+            commands::report_frontend_diagnostic
         ])
         .run(tauri::generate_context!())
         .expect("error while running Karlo");

--- a/src-tauri/src/media_protocol.rs
+++ b/src-tauri/src/media_protocol.rs
@@ -17,20 +17,33 @@ pub fn handle_media_request(
         return text_response(StatusCode::BAD_REQUEST, "invalid media path");
     };
 
-    if !is_allowed_media_path(&path, configured_roots) {
+    media_response_for_path(
+        &path,
+        method == tauri::http::Method::HEAD,
+        request
+            .headers()
+            .get(header::RANGE)
+            .and_then(|value| value.to_str().ok()),
+        configured_roots,
+    )
+}
+
+pub fn media_response_for_path(
+    path: &PathBuf,
+    is_head_request: bool,
+    range_header: Option<&str>,
+    configured_roots: &[PathBuf],
+) -> Response<Vec<u8>> {
+    if !is_allowed_media_path(path, configured_roots) {
         return text_response(
             StatusCode::FORBIDDEN,
             "media path is outside the allowed roots",
         );
     }
 
-    let range = request
-        .headers()
-        .get(header::RANGE)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| parse_byte_range(value));
+    let range = range_header.and_then(parse_byte_range);
 
-    file_response(&path, method == tauri::http::Method::HEAD, range)
+    file_response(path, is_head_request, range)
 }
 
 pub fn configured_media_roots(paths: &contract::CabinetPaths) -> Vec<PathBuf> {

--- a/src-tauri/src/media_protocol.rs
+++ b/src-tauri/src/media_protocol.rs
@@ -4,12 +4,20 @@ use std::path::PathBuf;
 
 use tauri::http::{header, Request, Response, StatusCode};
 
-pub fn handle_media_request(request: Request<Vec<u8>>) -> Response<Vec<u8>> {
+use crate::contract;
+
+const MAX_RANGE_RESPONSE_LEN: u64 = 1_000 * 1024;
+
+pub fn handle_media_request(
+    request: Request<Vec<u8>>,
+    configured_roots: &[PathBuf],
+) -> Response<Vec<u8>> {
+    let method = request.method().clone();
     let Some(path) = request_path(request.uri().path()) else {
         return text_response(StatusCode::BAD_REQUEST, "invalid media path");
     };
 
-    if !is_allowed_media_path(&path) {
+    if !is_allowed_media_path(&path, configured_roots) {
         return text_response(
             StatusCode::FORBIDDEN,
             "media path is outside the allowed roots",
@@ -22,7 +30,19 @@ pub fn handle_media_request(request: Request<Vec<u8>>) -> Response<Vec<u8>> {
         .and_then(|value| value.to_str().ok())
         .and_then(|value| parse_byte_range(value));
 
-    file_response(&path, range)
+    file_response(&path, method == tauri::http::Method::HEAD, range)
+}
+
+pub fn configured_media_roots(paths: &contract::CabinetPaths) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+
+    for root in &paths.media_roots {
+        push_non_empty_root(&mut roots, root);
+    }
+    push_non_empty_root(&mut roots, &paths.preview_video_root);
+    push_non_empty_root(&mut roots, &paths.artwork_root);
+
+    roots
 }
 
 fn request_path(uri_path: &str) -> Option<PathBuf> {
@@ -34,24 +54,30 @@ fn request_path(uri_path: &str) -> Option<PathBuf> {
     }
 }
 
-fn is_allowed_media_path(path: &PathBuf) -> bool {
+fn is_allowed_media_path(path: &PathBuf, configured_roots: &[PathBuf]) -> bool {
     let Ok(path) = path.canonicalize() else {
         return false;
     };
 
-    allowed_media_roots()
+    allowed_media_roots(configured_roots)
         .into_iter()
         .filter_map(|root| root.canonicalize().ok())
         .any(|root| path.starts_with(root))
 }
 
-fn allowed_media_roots() -> Vec<PathBuf> {
+fn allowed_media_roots(configured_roots: &[PathBuf]) -> Vec<PathBuf> {
     let mut roots = vec![PathBuf::from("/srv/karlo/library")];
 
     if let Some(home) = std::env::var_os("HOME") {
         let home = PathBuf::from(home);
         roots.push(home.join("Development/src/github.com/bentruyman/karlo-library"));
         roots.push(home.join("Downloads"));
+    }
+
+    for root in configured_roots {
+        if !roots.iter().any(|existing| existing == root) {
+            roots.push(root.clone());
+        }
     }
 
     roots
@@ -67,11 +93,29 @@ fn content_type_for(path: &PathBuf) -> &'static str {
         Some("mp4") => "video/mp4",
         Some("webm") => "video/webm",
         Some("mov") => "video/quicktime",
+        Some("png") => "image/png",
+        Some("jpg") | Some("jpeg") => "image/jpeg",
         _ => "application/octet-stream",
     }
 }
 
-fn file_response(path: &PathBuf, requested_range: Option<RequestedRange>) -> Response<Vec<u8>> {
+fn push_non_empty_root(roots: &mut Vec<PathBuf>, root: &str) {
+    let root = root.trim();
+    if root.is_empty() {
+        return;
+    }
+
+    let root = PathBuf::from(root);
+    if !roots.iter().any(|existing| existing == &root) {
+        roots.push(root);
+    }
+}
+
+fn file_response(
+    path: &PathBuf,
+    is_head_request: bool,
+    requested_range: Option<RequestedRange>,
+) -> Response<Vec<u8>> {
     let Ok(mut file) = File::open(path) else {
         return text_response(StatusCode::NOT_FOUND, "media file could not be read");
     };
@@ -84,6 +128,18 @@ fn file_response(path: &PathBuf, requested_range: Option<RequestedRange>) -> Res
     };
     let file_len = metadata.len();
 
+    if is_head_request {
+        return Response::builder()
+            .header(header::CONTENT_TYPE, content_type_for(path))
+            .header(header::CONTENT_LENGTH, file_len.to_string())
+            .header(header::ACCEPT_RANGES, "bytes")
+            .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+            .body(Vec::new())
+            .unwrap_or_else(|_| {
+                text_response(StatusCode::INTERNAL_SERVER_ERROR, "media response failed")
+            });
+    }
+
     if let Some(requested_range) = requested_range {
         let Some(range) = requested_range.resolve(file_len) else {
             return Response::builder()
@@ -93,6 +149,7 @@ fn file_response(path: &PathBuf, requested_range: Option<RequestedRange>) -> Res
                 .body(Vec::new())
                 .unwrap_or_else(|_| range_error_response());
         };
+        let range = range.with_max_len(MAX_RANGE_RESPONSE_LEN);
 
         return match read_file_range(&mut file, range.start, range.len()) {
             Ok(data) => Response::builder()
@@ -100,6 +157,7 @@ fn file_response(path: &PathBuf, requested_range: Option<RequestedRange>) -> Res
                 .header(header::CONTENT_TYPE, content_type_for(path))
                 .header(header::CONTENT_LENGTH, data.len().to_string())
                 .header(header::ACCEPT_RANGES, "bytes")
+                .header(header::ACCESS_CONTROL_EXPOSE_HEADERS, "content-range")
                 .header(
                     header::CONTENT_RANGE,
                     format!("bytes {}-{}/{}", range.start, range.end, file_len),
@@ -157,6 +215,17 @@ struct ResolvedRange {
 impl ResolvedRange {
     fn len(self) -> u64 {
         self.end - self.start + 1
+    }
+
+    fn with_max_len(self, max_len: u64) -> Self {
+        if max_len == 0 || self.len() <= max_len {
+            self
+        } else {
+            Self {
+                start: self.start,
+                end: self.start + max_len - 1,
+            }
+        }
     }
 }
 
@@ -287,9 +356,40 @@ mod tests {
             content_type_for(&PathBuf::from("preview.webm")),
             "video/webm"
         );
+        assert_eq!(content_type_for(&PathBuf::from("preview.png")), "image/png");
+        assert_eq!(
+            content_type_for(&PathBuf::from("preview.jpeg")),
+            "image/jpeg"
+        );
         assert_eq!(
             content_type_for(&PathBuf::from("preview.bin")),
             "application/octet-stream"
+        );
+    }
+
+    #[test]
+    fn configured_media_roots_include_all_cabinet_media_paths() {
+        let paths = contract::CabinetPaths {
+            mame_executable_path: String::new(),
+            mame_ini_path: None,
+            rom_roots: vec![],
+            media_roots: vec![
+                "/media/cabinet".to_owned(),
+                " ".to_owned(),
+                "/media/cabinet".to_owned(),
+            ],
+            preview_video_root: "/mnt/videos".to_owned(),
+            artwork_root: "/mnt/artwork".to_owned(),
+            category_ini_path: None,
+        };
+
+        assert_eq!(
+            configured_media_roots(&paths),
+            vec![
+                PathBuf::from("/media/cabinet"),
+                PathBuf::from("/mnt/videos"),
+                PathBuf::from("/mnt/artwork"),
+            ]
         );
     }
 
@@ -352,6 +452,30 @@ mod tests {
             }
             .resolve(10),
             None
+        );
+    }
+
+    #[test]
+    fn resolved_range_caps_open_ended_video_reads() {
+        assert_eq!(
+            RequestedRange {
+                start: Some(0),
+                end: None,
+            }
+            .resolve(10_000)
+            .map(|range| range.with_max_len(1_024)),
+            Some(ResolvedRange {
+                start: 0,
+                end: 1_023,
+            })
+        );
+    }
+
+    #[test]
+    fn resolved_range_keeps_small_reads_unchanged() {
+        assert_eq!(
+            ResolvedRange { start: 4, end: 11 }.with_max_len(1_024),
+            ResolvedRange { start: 4, end: 11 }
         );
     }
 }

--- a/src-tauri/src/media_server.rs
+++ b/src-tauri/src/media_server.rs
@@ -1,0 +1,305 @@
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
+
+use tauri::http::{header, Response, StatusCode};
+
+use crate::{media_protocol, store};
+
+const MAX_REQUEST_HEADER_LEN: usize = 16 * 1024;
+
+pub struct MediaHttpServer {
+    base_url: String,
+}
+
+impl MediaHttpServer {
+    pub fn start(state: store::AppState) -> Result<Self, String> {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).map_err(|error| error.to_string())?;
+        let address = listener
+            .local_addr()
+            .map_err(|error| format!("Could not read media server address: {error}"))?;
+        let base_url = format!("http://{address}");
+
+        thread::Builder::new()
+            .name("karlo-media-http".to_owned())
+            .spawn(move || {
+                for stream in listener.incoming() {
+                    match stream {
+                        Ok(stream) => {
+                            let state = state.clone();
+                            if let Err(error) = thread::Builder::new()
+                                .name("karlo-media-http-client".to_owned())
+                                .spawn(move || {
+                                    if let Err(error) = handle_connection(stream, &state) {
+                                        eprintln!("[karlo] media http request failed: {error}");
+                                    }
+                                })
+                            {
+                                eprintln!("[karlo] could not spawn media http client: {error}");
+                            }
+                        }
+                        Err(error) => eprintln!("[karlo] media http connection failed: {error}"),
+                    }
+                }
+            })
+            .map_err(|error| format!("Could not start media http server: {error}"))?;
+
+        Ok(Self { base_url })
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+fn handle_connection(mut stream: TcpStream, state: &store::AppState) -> Result<(), String> {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .map_err(|error| error.to_string())?;
+
+    let request = read_http_request(&mut stream)?;
+    let response = response_for_request(&request, state);
+    write_http_response(&mut stream, response)
+}
+
+fn response_for_request(request: &HttpRequest, state: &store::AppState) -> Response<Vec<u8>> {
+    if request.method != "GET" && request.method != "HEAD" {
+        return text_response(StatusCode::METHOD_NOT_ALLOWED, "method not allowed");
+    }
+
+    let Some(path) = media_path_from_target(&request.target) else {
+        return text_response(StatusCode::BAD_REQUEST, "invalid media request");
+    };
+
+    let configured_roots = state
+        .load_cabinet_config()
+        .map(|config| media_protocol::configured_media_roots(&config.paths))
+        .unwrap_or_default();
+
+    media_protocol::media_response_for_path(
+        &path,
+        request.method == "HEAD",
+        request.range.as_deref(),
+        &configured_roots,
+    )
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct HttpRequest {
+    method: String,
+    target: String,
+    range: Option<String>,
+}
+
+fn read_http_request(stream: &mut TcpStream) -> Result<HttpRequest, String> {
+    let mut data = Vec::new();
+    let mut buffer = [0; 1024];
+
+    while !data.windows(4).any(|window| window == b"\r\n\r\n") {
+        let read = stream
+            .read(&mut buffer)
+            .map_err(|error| error.to_string())?;
+        if read == 0 {
+            return Err("connection closed before request headers".to_owned());
+        }
+        data.extend_from_slice(&buffer[..read]);
+        if data.len() > MAX_REQUEST_HEADER_LEN {
+            return Err("request headers are too large".to_owned());
+        }
+    }
+
+    parse_http_request(&String::from_utf8_lossy(&data))
+}
+
+fn parse_http_request(raw: &str) -> Result<HttpRequest, String> {
+    let mut lines = raw.split("\r\n");
+    let request_line = lines
+        .next()
+        .ok_or_else(|| "missing request line".to_owned())?;
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts
+        .next()
+        .ok_or_else(|| "missing request method".to_owned())?
+        .to_owned();
+    let target = request_parts
+        .next()
+        .ok_or_else(|| "missing request target".to_owned())?
+        .to_owned();
+    let mut range = None;
+
+    for line in lines {
+        if line.is_empty() {
+            break;
+        }
+
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if name.trim().eq_ignore_ascii_case("range") {
+            range = Some(value.trim().to_owned());
+        }
+    }
+
+    Ok(HttpRequest {
+        method,
+        target,
+        range,
+    })
+}
+
+fn media_path_from_target(target: &str) -> Option<PathBuf> {
+    let (route, query) = target.split_once('?')?;
+    if route != "/media" {
+        return None;
+    }
+
+    for pair in query.split('&') {
+        let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
+        if percent_decode_query(name) != "path" {
+            continue;
+        }
+
+        let decoded = percent_decode_query(value);
+        if !is_device_file_path(&decoded) {
+            return None;
+        }
+
+        return Some(PathBuf::from(decoded));
+    }
+
+    None
+}
+
+fn is_device_file_path(path: &str) -> bool {
+    path.starts_with('/')
+        || path.starts_with("\\\\")
+        || path
+            .as_bytes()
+            .get(1..3)
+            .is_some_and(|bytes| bytes[0] == b':' && (bytes[1] == b'/' || bytes[1] == b'\\'))
+}
+
+fn percent_decode_query(value: &str) -> String {
+    let mut output = Vec::new();
+    let bytes = value.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'+' => {
+                output.push(b' ');
+                index += 1;
+            }
+            b'%' if index + 2 < bytes.len() => {
+                if let (Some(high), Some(low)) =
+                    (hex_value(bytes[index + 1]), hex_value(bytes[index + 2]))
+                {
+                    output.push(high << 4 | low);
+                    index += 3;
+                } else {
+                    output.push(bytes[index]);
+                    index += 1;
+                }
+            }
+            byte => {
+                output.push(byte);
+                index += 1;
+            }
+        }
+    }
+
+    String::from_utf8_lossy(&output).into_owned()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn write_http_response(stream: &mut TcpStream, response: Response<Vec<u8>>) -> Result<(), String> {
+    let (parts, body) = response.into_parts();
+    write!(
+        stream,
+        "HTTP/1.1 {} {}\r\n",
+        parts.status.as_u16(),
+        status_reason(parts.status)
+    )
+    .map_err(|error| error.to_string())?;
+
+    for (name, value) in &parts.headers {
+        let Ok(value) = value.to_str() else {
+            continue;
+        };
+        write!(stream, "{}: {value}\r\n", name.as_str()).map_err(|error| error.to_string())?;
+    }
+
+    if !parts.headers.contains_key(header::CONTENT_LENGTH) {
+        write!(stream, "content-length: {}\r\n", body.len()).map_err(|error| error.to_string())?;
+    }
+    write!(stream, "connection: close\r\n\r\n").map_err(|error| error.to_string())?;
+    stream.write_all(&body).map_err(|error| error.to_string())
+}
+
+fn status_reason(status: StatusCode) -> &'static str {
+    match status {
+        StatusCode::OK => "OK",
+        StatusCode::PARTIAL_CONTENT => "Partial Content",
+        StatusCode::BAD_REQUEST => "Bad Request",
+        StatusCode::FORBIDDEN => "Forbidden",
+        StatusCode::NOT_FOUND => "Not Found",
+        StatusCode::METHOD_NOT_ALLOWED => "Method Not Allowed",
+        StatusCode::RANGE_NOT_SATISFIABLE => "Range Not Satisfiable",
+        StatusCode::INTERNAL_SERVER_ERROR => "Internal Server Error",
+        _ => "OK",
+    }
+}
+
+fn text_response(status: StatusCode, body: &str) -> Response<Vec<u8>> {
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .header(header::CONTENT_LENGTH, body.len().to_string())
+        .body(body.as_bytes().to_vec())
+        .unwrap_or_else(|_| Response::new(Vec::new()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_range_header_from_request() {
+        let request = parse_http_request(
+            "GET /media?path=%2Fsrv%2Fvideo.mp4 HTTP/1.1\r\nRange: bytes=0-1\r\n\r\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            request,
+            HttpRequest {
+                method: "GET".to_owned(),
+                target: "/media?path=%2Fsrv%2Fvideo.mp4".to_owned(),
+                range: Some("bytes=0-1".to_owned()),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_media_path_query_parameter() {
+        assert_eq!(
+            media_path_from_target("/media?path=%2Fsrv%2Fkarlo%2Flibrary%2Fvideo+one.mp4"),
+            Some(PathBuf::from("/srv/karlo/library/video one.mp4"))
+        );
+        assert_eq!(media_path_from_target("/media?path=relative.mp4"), None);
+        assert_eq!(
+            media_path_from_target("/other?path=%2Ftmp%2Fvideo.mp4"),
+            None
+        );
+    }
+}

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -12,6 +12,7 @@ use crate::{contract, db, importer, seed};
 
 const DATABASE_FILENAME: &str = "karlo.sqlite3";
 
+#[derive(Clone)]
 pub struct AppState {
     db_path: PathBuf,
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' asset: http://asset.localhost; media-src 'self' asset: http://asset.localhost karlo-media: http://karlo-media.localhost",
+      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' asset: http://asset.localhost karlo-media: http://karlo-media.localhost; media-src 'self' asset: http://asset.localhost karlo-media: http://karlo-media.localhost",
       "assetProtocol": {
         "enable": true,
         "scope": [

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' asset: http://asset.localhost karlo-media: http://karlo-media.localhost; media-src 'self' asset: http://asset.localhost karlo-media: http://karlo-media.localhost",
+      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost http://127.0.0.1:*; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' asset: http://asset.localhost karlo-media: http://karlo-media.localhost; media-src 'self' asset: http://asset.localhost karlo-media: http://karlo-media.localhost http://127.0.0.1:*",
       "assetProtocol": {
         "enable": true,
         "scope": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -805,6 +805,8 @@ export default function App() {
 
   if (!selectedGame) return null;
 
+  const showBrowseChrome = !isAttractMode || isServiceOpen;
+
   return (
     <div
       className="isolate grid h-screen w-screen place-items-center overflow-hidden bg-black text-cab-ink antialiased"
@@ -828,31 +830,35 @@ export default function App() {
             left: `${displayCalibration.leftInsetPercent}%`,
           }}
         >
-          <ModeBar
-            browseViews={browseViews}
-            activeIndex={viewIndex}
-            isFocused={browseFocusZone === "modeBar"}
-            summaries={viewSummaries}
-            onFocusZone={() => setBrowseFocusZone("modeBar")}
-            onSelect={jumpToView}
-          />
+          {showBrowseChrome && (
+            <>
+              <ModeBar
+                browseViews={browseViews}
+                activeIndex={viewIndex}
+                isFocused={browseFocusZone === "modeBar"}
+                summaries={viewSummaries}
+                onFocusZone={() => setBrowseFocusZone("modeBar")}
+                onSelect={jumpToView}
+              />
 
-          <div className="grid grid-cols-[44%_1fr] gap-[3cqw] min-h-0">
-            <ListColumn
-              activeViewId={activeView.id}
-              games={visibleGames}
-              selectedIndex={activeSelectedIndex}
-              isFocused={browseFocusZone === "gameList"}
-              browseGroupState={browseGroupState}
-              onFocusZone={() => setBrowseFocusZone("gameList")}
-              onSelect={setSelection}
-              fallbackLabel={visibleState.fallbackLabel}
-            />
+              <div className="grid grid-cols-[44%_1fr] gap-[3cqw] min-h-0">
+                <ListColumn
+                  activeViewId={activeView.id}
+                  games={visibleGames}
+                  selectedIndex={activeSelectedIndex}
+                  isFocused={browseFocusZone === "gameList"}
+                  browseGroupState={browseGroupState}
+                  onFocusZone={() => setBrowseFocusZone("gameList")}
+                  onSelect={setSelection}
+                  fallbackLabel={visibleState.fallbackLabel}
+                />
 
-            <PreviewColumn game={selectedGame} isAttract={isAttractMode} />
-          </div>
+                <PreviewColumn game={selectedGame} />
+              </div>
 
-          <ControlHints launchStatus={launchStatus} />
+              <ControlHints launchStatus={launchStatus} />
+            </>
+          )}
         </div>
 
         {isAttractMode && !isServiceOpen && <AttractScreensaver />}
@@ -1428,7 +1434,7 @@ function BrowseMarkerRail({
   );
 }
 
-function PreviewColumn({ game, isAttract }: { game: GameRecord; isAttract: boolean }) {
+function PreviewColumn({ game }: { game: GameRecord }) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [unavailableMediaPaths, setUnavailableMediaPaths] = useState<Set<string>>(
     () => new Set(),
@@ -1450,6 +1456,8 @@ function PreviewColumn({ game, isAttract }: { game: GameRecord; isAttract: boole
     video.muted = true;
     video.load();
     startPreviewVideo(video, previewMedia.path);
+
+    return () => stopPreviewVideo(video);
   }, [previewMedia.kind, previewMediaPath, previewMediaSrc]);
 
   function markPreviewMediaUnavailable(path: string) {
@@ -1513,7 +1521,7 @@ function PreviewColumn({ game, isAttract }: { game: GameRecord; isAttract: boole
             style={{
               background:
                 "radial-gradient(ellipse at 50% 45%, color-mix(in srgb, var(--color-cab-accent) 14%, #000) 0%, #000 70%)",
-              opacity: isAttract ? 1 : 0.8,
+              opacity: 0.8,
             }}
           />
         )}
@@ -1580,6 +1588,12 @@ function startPreviewVideo(video: HTMLVideoElement, path?: string) {
       });
     });
   }
+}
+
+function stopPreviewVideo(video: HTMLVideoElement) {
+  video.pause();
+  video.removeAttribute("src");
+  video.load();
 }
 
 function logPreviewVideoError(video: HTMLVideoElement, path: string) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import {
   loadCabinetConfig,
   loadFrontendBootstrap,
   loadLibrarySnapshot,
+  reportFrontendDiagnostic,
   saveCabinetConfig,
   scanRomRoots,
   toggleGameFavorite,
@@ -1447,7 +1448,7 @@ function PreviewColumn({ game, isAttract }: { game: GameRecord; isAttract: boole
 
     video.muted = true;
     video.load();
-    startPreviewVideo(video);
+    startPreviewVideo(video, previewMedia.path);
   }, [previewMedia.kind, previewMediaPath, previewMediaSrc]);
 
   function markPreviewMediaUnavailable(path: string) {
@@ -1473,9 +1474,23 @@ function PreviewColumn({ game, isAttract }: { game: GameRecord; isAttract: boole
             loop
             playsInline
             preload="auto"
-            onCanPlay={(event) => startPreviewVideo(event.currentTarget)}
-            onLoadedData={(event) => startPreviewVideo(event.currentTarget)}
-            onError={() => markPreviewMediaUnavailable(previewMedia.path)}
+            onCanPlay={(event) =>
+              startPreviewVideo(event.currentTarget, previewMedia.path)
+            }
+            onLoadedData={(event) =>
+              startPreviewVideo(event.currentTarget, previewMedia.path)
+            }
+            onPlaying={(event) => {
+              reportPreviewVideoEvent(
+                "preview_video_playing",
+                event.currentTarget,
+                previewMedia.path,
+              );
+            }}
+            onError={(event) => {
+              logPreviewVideoError(event.currentTarget, previewMedia.path);
+              markPreviewMediaUnavailable(previewMedia.path);
+            }}
           />
         )}
 
@@ -1553,11 +1568,42 @@ function PreviewColumn({ game, isAttract }: { game: GameRecord; isAttract: boole
   );
 }
 
-function startPreviewVideo(video: HTMLVideoElement) {
+function startPreviewVideo(video: HTMLVideoElement, path?: string) {
   const playAttempt = video.play();
   if (playAttempt) {
-    void playAttempt.catch(() => undefined);
+    void playAttempt.catch((error: unknown) => {
+      if (!path) return;
+      void reportFrontendDiagnostic("preview_video_play_rejected", {
+        ...previewVideoDetails(video, path),
+        playError: error instanceof Error ? error.message : String(error),
+      });
+    });
   }
+}
+
+function logPreviewVideoError(video: HTMLVideoElement, path: string) {
+  const details = previewVideoDetails(video, path);
+  console.warn("[karlo] preview video failed", details);
+  void reportFrontendDiagnostic("preview_video_failed", details);
+}
+
+function reportPreviewVideoEvent(
+  event: string,
+  video: HTMLVideoElement,
+  path: string,
+) {
+  void reportFrontendDiagnostic(event, previewVideoDetails(video, path));
+}
+
+function previewVideoDetails(video: HTMLVideoElement, path: string) {
+  return {
+    path,
+    src: video.currentSrc || video.src,
+    errorCode: video.error?.code,
+    errorMessage: video.error?.message,
+    networkState: video.networkState,
+    readyState: video.readyState,
+  };
 }
 
 function Dot() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,7 @@ import {
   getGamesForView,
   jumpBrowseGroup,
 } from "./app/library";
-import { getPreviewMedia } from "./app/media";
+import { getPreviewMedia, setMediaHttpBaseUrl } from "./app/media";
 import type {
   BrowseView,
   BrowseViewId,
@@ -179,6 +179,7 @@ export default function App() {
     void Promise.all([loadFrontendBootstrap(), loadLibrarySnapshot()]).then(
       ([nextBootstrap, librarySnapshot]) => {
         if (cancelled) return;
+        setMediaHttpBaseUrl(nextBootstrap.mediaHttpBaseUrl);
         setBootstrap(nextBootstrap);
         applyLibrarySnapshot(librarySnapshot);
       },

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -125,6 +125,7 @@ export const DEFAULT_FRONTEND_BOOTSTRAP: FrontendBootstrap = {
     },
   },
   curation: DEFAULT_RUNTIME_CONTRACT.curation,
+  mediaHttpBaseUrl: null,
 };
 
 export const DEFAULT_LIBRARY_SNAPSHOT: LibrarySnapshot = {

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -196,3 +196,17 @@ export async function importMameCatalog(): Promise<LibraryMaintenanceResult> {
 export async function scanRomRoots(): Promise<LibraryMaintenanceResult> {
   return await invoke<LibraryMaintenanceResult>("scan_rom_roots");
 }
+
+export async function reportFrontendDiagnostic(
+  event: string,
+  details: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await invoke("report_frontend_diagnostic", {
+      event,
+      details: JSON.stringify(details),
+    });
+  } catch {
+    // Diagnostics must never interrupt cabinet browsing.
+  }
+}

--- a/src/app/media.test.ts
+++ b/src/app/media.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { getPreviewMedia, toMediaSrc, toVideoSrc } from "./media";
+import {
+  getPreviewMedia,
+  setMediaHttpBaseUrl,
+  toMediaSrc,
+  toVideoSrc,
+} from "./media";
 import type { GameRecord } from "./types";
 
 const baseGame: GameRecord = {
@@ -80,6 +85,17 @@ describe("toMediaSrc", () => {
 
 describe("toVideoSrc", () => {
   test("leaves relative paths unchanged outside Tauri", () => {
+    setMediaHttpBaseUrl(null);
     expect(toVideoSrc("media/previews/1942.mp4")).toBe("media/previews/1942.mp4");
+  });
+
+  test("uses the media HTTP server for device file paths", () => {
+    setMediaHttpBaseUrl("http://127.0.0.1:43210");
+
+    expect(toVideoSrc("/srv/karlo/library/media/mame/videos/1942 one.mp4")).toBe(
+      "http://127.0.0.1:43210/media?path=%2Fsrv%2Fkarlo%2Flibrary%2Fmedia%2Fmame%2Fvideos%2F1942+one.mp4",
+    );
+
+    setMediaHttpBaseUrl(null);
   });
 });

--- a/src/app/media.ts
+++ b/src/app/media.ts
@@ -39,12 +39,21 @@ export function toMediaSrc(path: string) {
   try {
     return convertFileSrc(path);
   } catch {
-    return path;
+    return toKarloMediaSrc(path);
   }
 }
 
 export function toVideoSrc(path: string) {
   if (!isDeviceFilePath(path) || !isTauri()) return path;
+
+  try {
+    return convertFileSrc(path);
+  } catch {
+    return toKarloMediaSrc(path);
+  }
+}
+
+function toKarloMediaSrc(path: string) {
   return `karlo-media://localhost/${encodeURIComponent(path)}`;
 }
 

--- a/src/app/media.ts
+++ b/src/app/media.ts
@@ -2,10 +2,16 @@ import { convertFileSrc, isTauri } from "@tauri-apps/api/core";
 
 import type { GameRecord } from "./types";
 
+let mediaHttpBaseUrl: string | null = null;
+
 export type PreviewMedia =
   | { kind: "video"; path: string; src: string }
   | { kind: "image"; path: string; src: string }
   | { kind: "none" };
+
+export function setMediaHttpBaseUrl(baseUrl: string | null | undefined) {
+  mediaHttpBaseUrl = baseUrl?.trim() || null;
+}
 
 export function getPreviewMedia(
   game: GameRecord,
@@ -44,6 +50,9 @@ export function toMediaSrc(path: string) {
 }
 
 export function toVideoSrc(path: string) {
+  const httpSrc = toMediaHttpSrc(path);
+  if (httpSrc) return httpSrc;
+
   if (!isDeviceFilePath(path) || !isTauri()) return path;
 
   try {
@@ -55,6 +64,18 @@ export function toVideoSrc(path: string) {
 
 function toKarloMediaSrc(path: string) {
   return `karlo-media://localhost/${encodeURIComponent(path)}`;
+}
+
+function toMediaHttpSrc(path: string) {
+  if (!mediaHttpBaseUrl || !isDeviceFilePath(path)) return null;
+
+  try {
+    const url = new URL("/media", mediaHttpBaseUrl);
+    url.searchParams.set("path", path);
+    return url.toString();
+  } catch {
+    return null;
+  }
 }
 
 function isDeviceFilePath(path: string) {

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -123,6 +123,7 @@ export interface FrontendBootstrap {
   defaultView: BrowseViewId;
   cabinetConfig: CabinetConfig;
   curation: CurationContract;
+  mediaHttpBaseUrl: string | null;
 }
 
 export interface LibrarySnapshot {


### PR DESCRIPTION
## Summary
- Serve preview videos through a local loopback HTTP endpoint so WebKitGTK can play them reliably on the cabinet
- Stop mounting preview video playback while attract mode is active to prevent the screensaver from leaking or stuttering
- Keep cabinet provisioning, CSP, and Linux artifact packaging aligned with the new media path

## Testing
- `bun test`
- `bun run build`
- `cargo fmt -- --check`
- `cargo test`
- Verified on the cabinet with SSH and log output that preview videos play via the loopback HTTP URL and stop during attract mode