### PR TITLE
Fix display titles to trim MAME metadata

### DIFF
--- a/src/app/browse.test.ts
+++ b/src/app/browse.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   buildGameRecords,
+  formatGameTitleForDisplay,
   getBrowseGroupState,
   getBrowseViewSummary,
   getGamesForView,
@@ -146,6 +147,43 @@ function titlesFor(games: GameRecord[]) {
 }
 
 describe("buildGameRecords", () => {
+  test("uses front-end display titles without trailing MAME metadata", () => {
+    const importedGames: ImportedGameRecord[] = [
+      {
+        machineName: "galaga",
+        title: "Galaga (US SET 1)",
+        year: 1981,
+        manufacturer: "Namco",
+        genre: "Fixed Shooter",
+        romAvailable: true,
+        artworkPaths: [],
+      },
+      {
+        machineName: "robotron",
+        title: "Robotron: 2084 (REV 2)",
+        year: 1982,
+        manufacturer: "Williams",
+        genre: "Arena Shooter",
+        romAvailable: true,
+        artworkPaths: [],
+      },
+    ];
+    const libraryEntries: LibraryEntryRecord[] = importedGames.map(
+      (game, index) => ({
+        machineName: game.machineName,
+        isVisible: true,
+        isFavorite: false,
+        browseSortOrder: index,
+        includeInAttractMode: true,
+      }),
+    );
+
+    expect(titlesFor(buildGameRecords(importedGames, libraryEntries, []))).toEqual([
+      "Galaga",
+      "Robotron: 2084",
+    ]);
+  });
+
   test("joins imported catalog, curated library entries, and recent history", () => {
     const importedGames: ImportedGameRecord[] = [
       {
@@ -286,6 +324,25 @@ describe("buildGameRecords", () => {
         wasRecentlyPlayed: false,
       },
     ]);
+  });
+});
+
+describe("formatGameTitleForDisplay", () => {
+  test("removes trailing region, set, and revision metadata", () => {
+    expect(formatGameTitleForDisplay("Galaga (US SET 1)")).toBe("Galaga");
+    expect(formatGameTitleForDisplay("Robotron: 2084 (REV 2)")).toBe(
+      "Robotron: 2084",
+    );
+    expect(formatGameTitleForDisplay("Wonder Boy (World) (set 1)")).toBe(
+      "Wonder Boy",
+    );
+    expect(formatGameTitleForDisplay("Alpha [ver AAA]")).toBe("Alpha");
+  });
+
+  test("preserves parenthetical title text that does not look like metadata", () => {
+    expect(formatGameTitleForDisplay("Game Title (Deluxe Edition)")).toBe(
+      "Game Title (Deluxe Edition)",
+    );
   });
 });
 

--- a/src/app/library.ts
+++ b/src/app/library.ts
@@ -18,8 +18,32 @@ export interface BrowseViewSummary {
   statValue: number;
 }
 
+const TRAILING_TITLE_METADATA_PATTERN = /\s*(?:\(([^()]*)\)|\[([^\]]*)\])\s*$/;
+const TITLE_METADATA_MARKERS = [
+  /\b(?:rev(?:ision)?|set|ver(?:sion)?|proto(?:type)?|bootleg|hack)\b/i,
+  /\b(?:u\.?s\.?a?|japan(?:ese)?|world|euro(?:pe|pean)?|asia(?:n)?|korea(?:n)?|taiwan(?:ese)?|china|chinese|hong kong|brazil(?:ian)?|canada|canadian|australia(?:n)?|new zealand|nz|italy|italian|france|french|germany|german|spain|spanish|uk)\b/i,
+  /\b(?:[a-z]{2,4}\d{2,}|\d{6,})\b/i,
+];
+
 function compareByTitle(left: GameRecord, right: GameRecord) {
   return left.title.localeCompare(right.title);
+}
+
+export function formatGameTitleForDisplay(title: string) {
+  const fallback = title.trim();
+  let displayTitle = fallback.replace(/\s+/g, " ");
+
+  while (displayTitle.length > 0) {
+    const match = displayTitle.match(TRAILING_TITLE_METADATA_PATTERN);
+    if (!match?.index) break;
+
+    const metadata = match[1] ?? match[2] ?? "";
+    if (!TITLE_METADATA_MARKERS.some((marker) => marker.test(metadata))) break;
+
+    displayTitle = displayTitle.slice(0, match.index).trim();
+  }
+
+  return displayTitle || fallback;
 }
 
 export function buildGameRecords(
@@ -43,6 +67,7 @@ export function buildGameRecords(
         {
           id: game.machineName,
           ...game,
+          title: formatGameTitleForDisplay(game.title),
           isFavorite: libraryEntry.isFavorite,
           wasRecentlyPlayed: recentByMachine.has(game.machineName),
         },


### PR DESCRIPTION
## Summary
- Normalize imported game titles before they reach the frontend so trailing MAME metadata like regions, set numbers, and revision tags are hidden in the UI.
- Keep the original imported data intact while applying the cleaned title across browse rows, sorting, and preview views.
- Add unit coverage for both the shared title formatter and the game record build path.

## Testing
- Added Bun unit tests for title cleanup cases and for preserving non-metadata parenthetical text.
- Local validation passed with the frontend test suite and production build.